### PR TITLE
docs: adjust the layout

### DIFF
--- a/docs/zh/guide/started/index.md
+++ b/docs/zh/guide/started/index.md
@@ -1,8 +1,8 @@
 # 开始
 
-尝试 Strve.js 的一种方法是使用直接引入 CDN 链接。 您可以在浏览器中打开它并按照示例学习一些基本用法。
+尝试 Strve.js 的一种方法是使用直接引入 CDN 链接。您可以在浏览器中打开它并按照示例学习一些基本用法。
 
-需要注意的是，Strve.js的源码是由ES Modules管理的，所以直接在浏览器中使用的时候，需要在`script`标签中添加`type="module"`属性来表明这个 文件被用作`module`的方式来运行。
+需要注意的是，Strve.js 的源码是由 ES Modules 管理的，所以直接在浏览器中使用的时候，需要在 `<script>` 标签中添加 `type="module"` 属性来表明这个文件被用作 `module` 的方式来运行。
 
 ```html
 <!DOCTYPE html>
@@ -25,17 +25,17 @@
 				count: 0,
 			};
 
-			function App() {
-				return h`
-            <h1 $key>${state.count}</h1>
-            <button onClick=${add}>Add</button> 
-        `;
-			}
-
 			function add() {
 				setData(() => {
 					state.count++;
 				});
+			}
+
+			function App() {
+				return h`
+					<h1 $key>${state.count}</h1>
+					<button onClick=${add}>Add</button> 
+        		`;
 			}
 
 			const app = createApp(App);
@@ -45,7 +45,7 @@
 </html>
 ```
 
-当然你也可以使用在`script`标签直接引入，这样就可以直接在浏览器中打开了。
+当然您也可以选择使用 `<script>` 标签直接引入，这样就可以直接在浏览器中打开了。
 
 ```html
 <!DOCTYPE html>
@@ -62,18 +62,18 @@
 			const state = {
 				count: 0,
 			};
-
-			function App() {
-				return $h`
-            <h1 $key>${state.count}</h1>
-            <button onClick=${add}>Add</button> 
-        `;
-			}
-
+			
 			function add() {
 				$setData(() => {
 					state.count++;
 				});
+			}
+
+			function App() {
+				return $h`
+					<h1 $key>${state.count}</h1>
+					<button onClick=${add}>Add</button> 
+				`;
 			}
 
 			const app = $createApp(App);


### PR DESCRIPTION
- 中英之间添加一定间隔
- `script` 改为 `<script>`，显式表明标签身份
- 修改示例代码前后顺序，更符合先声明后使用的风格，不借助函数声明提升